### PR TITLE
chore: upgrade actions/create-github-app-token to v3, use client-id

### DIFF
--- a/.github/workflows/azure-static-web-app-advanced.yml
+++ b/.github/workflows/azure-static-web-app-advanced.yml
@@ -68,10 +68,10 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Azure login
         uses: azure/login@v2


### PR DESCRIPTION
## Summary

Upgrades `actions/create-github-app-token` to `@v3` and migrates from the deprecated `app-id` input to `client-id`.

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input from `app-id` to `client-id` ([v3 changelog](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0))
- 📝 Renamed variable references to use `*_CLIENT_ID` naming

### ✅ Variable Updates
- New variable(s) created: `APP_CLIENT_ID`
- Workflow updated to reference the new variable(s)

### 🧹 After Merging
Delete the old variable(s) that are no longer referenced: `APP_ID`